### PR TITLE
feat: migrate from heroku add-on to mongdb atlas

### DIFF
--- a/config/index.js
+++ b/config/index.js
@@ -1,6 +1,11 @@
-const mongodbUri =
-  process.env.NODE_ENV === 'development'
-    ? 'mongodb://localhost/mascotapp'
-    : process.env.MONGODB_URI;
+const mongodbUri = () => {
+  const processObject = {
+    local: 'mongodb://localhost/mascotapp',
+    staging: process.env.MONGODB_URI_STAGING,
+    production: process.env.MONGODB_URI_PRODUCTION
+  };
 
-module.exports = mongodbUri;
+  return processObject[process.env.NODE_ENV];
+};
+
+module.exports = mongodbUri();

--- a/package-lock.json
+++ b/package-lock.json
@@ -1770,6 +1770,15 @@
         "capture-stack-trace": "^1.0.0"
       }
     },
+    "cross-env": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-7.0.2.tgz",
+      "integrity": "sha512-KZP/bMEOJEDCkDQAyRhu3RL2ZO/SUVrxQVI0G3YEQ+OLbRA3c6zgixe8Mq8a/z7+HKlNEjo8oiLUs8iRijY2Rw==",
+      "dev": true,
+      "requires": {
+        "cross-spawn": "^7.0.1"
+      }
+    },
     "cross-spawn": {
       "version": "7.0.3",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",

--- a/package.json
+++ b/package.json
@@ -12,9 +12,9 @@
     "server:local": "cross-env NODE_ENV=local nodemon index.js",
     "server:staging": "cross-env NODE_ENV=staging nodemon index.js",
     "server:production": "cross-env NODE_ENV=production nodemon index.js",
-    "repl:local": "NODE_ENV=local NODE_OPTIONS=--experimental-repl-await node repl.js",
-    "repl:staging": "NODE_ENV=staging NODE_OPTIONS=--experimental-repl-await node repl.js",
-    "repl:production": "NODE_ENV=production NODE_OPTIONS=--experimental-repl-await node repl.js"
+    "repl:local": "cross-env NODE_ENV=local NODE_OPTIONS=--experimental-repl-await node repl.js",
+    "repl:staging": "cross-env NODE_ENV=staging NODE_OPTIONS=--experimental-repl-await node repl.js",
+    "repl:production": "cross-env NODE_ENV=production NODE_OPTIONS=--experimental-repl-await node repl.js"
   },
   "jest": {
     "testEnvironment": "node",

--- a/package.json
+++ b/package.json
@@ -4,15 +4,17 @@
   "description": "Main back-end for the pliplox project",
   "main": "index.js",
   "scripts": {
-    "start": "NODE_ENV=production node index.js",
+    "start": "cross-env NODE_ENV=production node index.js",
     "test": "jest --detectOpenHandles --forceExit",
     "test:watch": "jest --detectOpenHandles --forceExit --watch",
     "test:debug": "node --inspect node_modules/.bin/jest --detectOpenHandles",
     "test:debug:windows": "node --inspect-brk ./node_modules/jest/bin/jest.js --runInBand --detectOpenHandles",
-    "server": "NODE_ENV=development nodemon index.js",
-    "server:windows": "SET NODE_ENV=development& nodemon index.js",
-    "repl": "NODE_ENV=development NODE_OPTIONS=--experimental-repl-await node repl.js",
-    "repl:windows": "SET NODE_ENV=development&&SET NODE_OPTIONS=--experimental-repl-await& node repl.js"
+    "server:local": "cross-env NODE_ENV=local nodemon index.js",
+    "server:staging": "cross-env NODE_ENV=staging nodemon index.js",
+    "server:production": "cross-env NODE_ENV=production nodemon index.js",
+    "repl:local": "NODE_ENV=local NODE_OPTIONS=--experimental-repl-await node repl.js",
+    "repl:staging": "NODE_ENV=staging NODE_OPTIONS=--experimental-repl-await node repl.js",
+    "repl:production": "NODE_ENV=production NODE_OPTIONS=--experimental-repl-await node repl.js"
   },
   "jest": {
     "testEnvironment": "node",
@@ -45,6 +47,7 @@
   },
   "devDependencies": {
     "@shelf/jest-mongodb": "^1.1.3",
+    "cross-env": "^7.0.2",
     "eslint": "^6.5.1",
     "eslint-config-airbnb-base": "^14.0.0",
     "eslint-config-prettier": "^6.4.0",


### PR DESCRIPTION
- Add `cross-env` package
- Modify scripts to work with `cross-env`
- Modify URIs to work with local, staging and production (this may be a work in progress)