### PR TITLE
[FIX] Encrypt user password

### DIFF
--- a/models/User.js
+++ b/models/User.js
@@ -67,14 +67,15 @@ const userSchema = new Schema({
   ]
 });
 
-// eslint-disable-next-line func-names
-userSchema.pre('save', async function(next) {
-  // eslint-disable-next-line prefer-const
-  let user = this;
-  const hash = await bcrypt.hash(user.password, 10);
-  if (!hash) next(new Error('Error hashing the password'));
-  user.password = hash;
-  next();
+userSchema.pre('save', async function encriptPassword(next) {
+  if (!this.isModified('password')) return next();
+  try {
+    this.password = await bcrypt.hash(this.password, 10);
+    return next();
+  } catch (e) {
+    return next(e);
+  }
+  
 });
 
 module.exports = mongoose.model('User', userSchema);

--- a/test/models/User.test.js
+++ b/test/models/User.test.js
@@ -1,0 +1,80 @@
+const faker = require('faker');
+const mongoose = require('mongoose');
+const bcrypt = require('bcryptjs');
+const databaseHandler = require('../helpers/databaseHandler');
+const User = require('../../models/User');
+
+describe('User model', () => {
+  beforeAll(async () => databaseHandler.openConnection());
+
+  afterAll(async () => databaseHandler.closeConnection());
+
+  afterEach(async () => databaseHandler.deleteCollections());
+
+  const {
+    name: { firstName },
+    internet: { email, password }
+  } = faker;
+
+  const mockedUserData = { name: firstName(), email: email(), password: password() };
+
+  beforeEach(async () => User.create(mockedUserData));
+
+  it('creates and save a User instance', async () => {
+    const user = await User.findOne({ email: mockedUserData.email });
+    expect(user._id).toBeDefined();
+  });
+
+  it('fails when required property is not set', async () => {
+    const userWithoutRequiredField = new User();
+    let err;
+    try {
+      const savedUserWithoutRequiredField = await userWithoutRequiredField.save();
+      err = savedUserWithoutRequiredField;
+    } catch (error) {
+      err = error;
+    }
+    expect(err).toBeInstanceOf(mongoose.Error.ValidationError);
+    const {
+      errors: { name, email: emailError, password: passwordError }
+    } = err;
+    expect(name).toBeDefined();
+    expect(emailError).toBeDefined();
+    expect(passwordError).toBeDefined();
+  });
+
+  describe('When user is updated', () => {
+    let user;
+    beforeEach(async () => {
+      user = await User.findOne({ email: mockedUserData.email });
+    });
+
+    describe('when updating the password', () => {
+      const newPassword = 'awesome new password';
+      let updatedUser;
+
+      beforeEach(async () => {
+        user.password = newPassword;
+        updatedUser = await user.save();
+      });
+
+      it('encrypts the new password', async () => {
+        expect(bcrypt.compareSync(newPassword, updatedUser.password)).toBeTruthy();
+      });
+    });
+
+    describe('When not updating the password', () => {
+      const newEmail = faker.internet.email();
+      let updatedUser;
+
+      beforeEach(async () => {
+        user.email = newEmail;
+        updatedUser = await user.save();
+      });
+
+      it('does not encrypt the password', async () => {
+        expect(bcrypt.compareSync(mockedUserData.password, updatedUser.password)).toBeTruthy();
+      });
+    });
+  });
+});


### PR DESCRIPTION
- Encrypt password only when is updated or a new user instance

> Note: this is only applied to te pre "save" method, so if you use `update` it will not run the middleware, this is due to the update method skips model validations